### PR TITLE
v0.3.5 - Credentials - Updates order of precedence for argocd values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@garage-catalyst/ibm-garage-cloud-cli",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "CLI that wraps IBM Cloud CLI to simplify build and deploy image functions",
   "main": "dist/index.js",
   "author": "Sean Sundberg <seansund@us.ibm.com>",

--- a/src/commands/credentials/credentials.ts
+++ b/src/commands/credentials/credentials.ts
@@ -96,12 +96,12 @@ export class CredentialsImpl implements Credentials {
     const listOptions: ListOptions<any> = {namespace, qs};
 
     const results: Array<Array<object>> = await Promise.all([
-      this.kubeConfigMap.listData(listOptions, ['ibmcloud-config']),
-      this.kubeSecret.listData(listOptions, ['jenkins-access']),
       Promise.all([
         this.getArgoCdCredentials(namespace),
         this.getJenkinsCredentials(namespace),
       ]),
+      this.kubeConfigMap.listData(listOptions, ['ibmcloud-config']),
+      this.kubeSecret.listData(listOptions, ['jenkins-access']),
     ]);
 
     return this.group(_.assign({}, ...(_.flatten(results))));


### PR DESCRIPTION
Changes order of precedence to allow argocd secret values to be used instead of pod name when both values are present. The `argocd-access` secret should be used going forward but the pod name logic will remain for a period of time for backwards compatibility