### PR TITLE
Updates to cluster-config handling for pipeline

### DIFF
--- a/src/commands/register-pipeline.ts
+++ b/src/commands/register-pipeline.ts
@@ -9,6 +9,7 @@ import {ErrorSeverity, isCommandError} from '../util/errors';
 import {isPipelineError, PipelineErrorType} from '../services/register-pipeline/register-pipeline';
 import * as chalk from 'chalk';
 import {QuestionBuilder} from '../util/question-builder';
+import {isClusterConfigNotFound} from '../util/cluster-type';
 
 export const command = 'pipeline';
 export const desc = 'Register a pipeline for the current code repository';
@@ -123,7 +124,11 @@ exports.handler = async (argv: Arguments<RegisterPipelineOptions & CommandLineOp
       spinner.stop();
     }
 
-    if (isCommandError(err)) {
+    if (isClusterConfigNotFound(err)) {
+      console.log(chalk.red(`Cluster configuration not found in the namespace - ${err.namespace}/${err.configMapName}`));
+      console.log('It looks like the namespace needs to be set up for development by running ' + chalk.yellow(`${argv.$0} sync ${err.namespace} --dev`));
+      process.exit(1);
+    } else if (isCommandError(err)) {
       if (err.type.severity === ErrorSeverity.WARNING) {
         console.log(`Warning: ${err.message}`);
         process.exit(0)

--- a/src/services/register-pipeline/register-jenkins-pipeline.ts
+++ b/src/services/register-pipeline/register-jenkins-pipeline.ts
@@ -59,9 +59,15 @@ export class RegisterJenkinsPipeline implements RegisterPipeline {
 
   async registerPipeline(cliOptions: RegisterPipelineOptions, notifyStatus: (status: string) => void = noopNotifyStatus) {
 
-    const {clusterType, serverUrl} = await this.clusterType.getClusterType(cliOptions.templateNamespace);
+    const templateConfig = await this.clusterType.getClusterType(cliOptions.templateNamespace);
 
-    const options: RegisterPipelineOptions = await this.setupDefaultOptions(clusterType, serverUrl, cliOptions);
+    const options: RegisterPipelineOptions = await this.setupDefaultOptions(
+      templateConfig.clusterType,
+      templateConfig.serverUrl,
+      cliOptions
+    );
+
+    const {clusterType} = await this.clusterType.getClusterType(options.pipelineNamespace);
 
     notifyStatus(`Creating pipeline on ${chalk.yellow(clusterType)} cluster in ${chalk.yellow(options.pipelineNamespace)} namespace`);
 

--- a/src/services/register-pipeline/register-tekton-pipeline.spec.ts
+++ b/src/services/register-pipeline/register-tekton-pipeline.spec.ts
@@ -121,7 +121,7 @@ describe('register-tekton-pipeline', () => {
     });
 
     const pipelineNamespace = 'test';
-    const templateNamespace = 'tools;';
+    const templateNamespace = 'tools';
     const notifyStatus = (text: string) => undefined;
 
     describe('when namespace exists', () => {
@@ -154,7 +154,7 @@ describe('register-tekton-pipeline', () => {
         let options = {pipelineNamespace, templateNamespace};
         await classUnderTest.registerPipeline(options, notifyStatus);
 
-        expect(getClusterType).toHaveBeenCalledWith(templateNamespace);
+        expect(getClusterType).toHaveBeenCalledWith(pipelineNamespace);
       });
 
       test('should get git parameters', async () => {
@@ -331,7 +331,7 @@ describe('register-tekton-pipeline', () => {
         const url = await classUnderTest.buildImageUrl(options, {repo});
 
         expect(url).toEqual(`${registryUrl}/${registryNamespace}/${repo}:latest`);
-        expect(kubeConfigMap.get).toHaveBeenCalledWith('ibmcloud-config', options.templateNamespace);
+        expect(kubeConfigMap.get).toHaveBeenCalledWith('ibmcloud-config', options.pipelineNamespace);
       });
     });
 
@@ -357,7 +357,7 @@ describe('register-tekton-pipeline', () => {
         const url = await classUnderTest.buildImageUrl(options, {repo});
 
         expect(url).toEqual(`${registryUrl}/${options.pipelineNamespace}/${repo}:latest`);
-        expect(kubeConfigMap.get).toHaveBeenCalledWith('ibmcloud-config', options.templateNamespace);
+        expect(kubeConfigMap.get).toHaveBeenCalledWith('ibmcloud-config', options.pipelineNamespace);
       });
     });
 

--- a/src/services/register-pipeline/register-tekton-pipeline.ts
+++ b/src/services/register-pipeline/register-tekton-pipeline.ts
@@ -63,9 +63,11 @@ export class RegisterTektonPipeline implements RegisterPipeline {
 
   async registerPipeline(cliOptions: RegisterPipelineOptions, notifyStatus: (text: string) => void = noopNotifyStatus) {
 
-    const {clusterType} = await this.clusterType.getClusterType(cliOptions.templateNamespace);
+    const templateConfig = await this.clusterType.getClusterType(cliOptions.templateNamespace);
 
-    const options: RegisterPipelineOptions = await this.setupDefaultOptions(clusterType, cliOptions);
+    const options: RegisterPipelineOptions = await this.setupDefaultOptions(templateConfig.clusterType, cliOptions);
+
+    const {clusterType} = await this.clusterType.getClusterType(options.pipelineNamespace);
 
     notifyStatus(`Creating pipeline on ${chalk.yellow(clusterType)} cluster in ${chalk.yellow(options.pipelineNamespace)} namespace`);
 
@@ -231,7 +233,7 @@ export class RegisterTektonPipeline implements RegisterPipeline {
 
   async buildImageUrl(options: TektonPipelineOptions, params: { repo: string }): Promise<string> {
 
-    const containerConfig: ConfigMap<IBMCloudConfig> = await this.configMap.get('ibmcloud-config', options.templateNamespace);
+    const containerConfig: ConfigMap<IBMCloudConfig> = await this.configMap.get('ibmcloud-config', options.pipelineNamespace);
     if (!containerConfig || !containerConfig.data) {
       throw new Error('Unable to retrieve config map: ibmcloud-config');
     }

--- a/src/util/cluster-type.spec.ts
+++ b/src/util/cluster-type.spec.ts
@@ -1,0 +1,77 @@
+import {Container} from 'typescript-ioc';
+
+import {ClusterType, isClusterConfigNotFound} from './cluster-type';
+import {KubeConfigMap, KubeSecret} from '../api/kubectl';
+import {providerFromValue} from '../testHelper';
+import Mock = jest.Mock;
+
+describe('cluster-type', () => {
+  test('canary verifies test infrastructure', () => {
+    expect(true).toEqual(true);
+  });
+
+  let classUnderTest: ClusterType;
+
+  let getData: Mock;
+
+  beforeEach(() => {
+    getData = jest.fn();
+
+    const kubeConfigMap = {
+      getData,
+    };
+    Container.bind(KubeConfigMap).provider(providerFromValue(kubeConfigMap));
+
+    classUnderTest = Container.get(ClusterType);
+  });
+
+  describe('given getClusterType()', () => {
+    const clusterType = 'cluster type';
+    const serverUrl = 'server url';
+
+    describe('when cluster-config config map exists', () => {
+      beforeEach(() => {
+        getData.mockResolvedValue({CLUSTER_TYPE: clusterType, SERVER_URL: serverUrl});
+      });
+
+      test('then return clusterType and serverUrl', async () => {
+        const namespace = 'namespace';
+        expect(await classUnderTest.getClusterType(namespace))
+          .toEqual({clusterType, serverUrl});
+
+        expect(getData).toHaveBeenCalledWith('cluster-config', namespace);
+      });
+    });
+
+    describe('when cluster-config config map does not exist', () => {
+      beforeEach(() => {
+        getData.mockRejectedValueOnce(new Error('not found'));
+        getData.mockResolvedValue({CLUSTER_TYPE: clusterType, SERVER_URL: serverUrl});
+      });
+
+      test('then get clusterType and serverUrl from ibmcloud-config config map', async () => {
+        const namespace = 'namespace';
+        expect(await classUnderTest.getClusterType(namespace))
+          .toEqual({clusterType, serverUrl});
+
+        expect(getData).toHaveBeenCalledTimes(2);
+        expect(getData.mock.calls[0]).toEqual(['cluster-config', namespace]);
+        expect(getData.mock.calls[1]).toEqual(['ibmcloud-config', namespace]);
+      });
+
+      describe('and when ibmcloud-config does not exist', () => {
+        beforeEach(() => {
+          getData.mockRejectedValue(new Error('not found'));
+        });
+
+        test('then throw ClusterConfigNotFound', async () => {
+          return classUnderTest.getClusterType('my-namespace')
+            .then(value => fail('should throw error'))
+            .catch(err => {
+              expect(isClusterConfigNotFound(err)).toEqual(true);
+            });
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
- getClusterType checks cluster-config and ibmcloud-config config maps then throws error
- pipeline command for jenkins and tekton gets cluster type from pipeline namespace
- pipeline command for tekton use config from pipeline namespace to create image pipeline resource
- pipeline command bootstrap config from tools namespace first then test the config in pipeline namespace