### PR TITLE
remove jsonpath whitespace

### DIFF
--- a/src/services/namespace/namespace.ts
+++ b/src/services/namespace/namespace.ts
@@ -71,9 +71,11 @@ export class NamespaceImpl implements Namespace{
         .replace(/"/g, '');
 
       if (currentContext) {
-        const {stdout} = await this.childProcess.exec(`kubectl config view -o jsonpath='{.contexts[?(@.name == "${currentContext}")].context.namespace}'`);
+        const {stdout} = await this.childProcess.exec(`kubectl config view -o jsonpath='{.contexts[?(@.name=="'${currentContext}'")].context.namespace}'`);
 
-        const value = stdout.toString().trim();
+        const value = stdout.toString()
+          .trim()
+          .replace(/'/g,'');
 
         return value != 'default' ? value : defaultValue;
       }


### PR DESCRIPTION
Sort of a WIP

Fix for #39 - tested on Win10 and MacOSX. Removed whitespace in path spec for querying the kubectl context and placed single quotes to avoid 2nd `@` from causing the email address in the OCP user. Dropped single quotes in namespace response from context.