### PR TITLE
git-repo: Updates for usability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ibmgaragecloud/cloud-native-toolkit-cli",
-  "version": "0.5.10-beta.3",
+  "version": "0.5.10-beta.4",
   "description": "CLI that provides functions to simplify interactions with containerized platforms and tools",
   "main": "dist/index.js",
   "author": "Sean Sundberg <seansund@us.ibm.com>",
@@ -14,6 +14,7 @@
     "kubectl-dashboard": "dist/script-dashboard.js",
     "kubectl-enable": "dist/script-enable.js",
     "kubectl-endpoints": "dist/script-endpoints.js",
+    "kubectl-git": "dist/script-git.js",
     "kubectl-git-secret": "dist/script-git-secret.js",
     "kubectl-pipeline": "dist/script-pipeline.js",
     "kubectl-sync": "dist/script-namespace.js",

--- a/src/commands/git-repo.ts
+++ b/src/commands/git-repo.ts
@@ -6,6 +6,7 @@ import {CommandLineOptions} from '../model';
 import {GetGitParameters} from '../services/git-secret';
 
 export const command = 'git-repo [remote]';
+export const aliases = ['git'];
 export const desc = 'Launches a browser to the git repo url specified by the origin remote';
 export const builder = (argv: Argv<any>) => argv
   .positional('remote', {

--- a/src/script-git.ts
+++ b/src/script-git.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+import {addCommandToArgs} from './util/add-command-to-args';
+
+process.argv = addCommandToArgs(process.argv, 'git');
+
+require('./script');


### PR DESCRIPTION
- Adds `git` alias for `git-repo`
- Adds script to install `git` command as a plugin to kubectl
