### PR TITLE
Simplifies logic to determine the cluster type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3680,9 +3680,9 @@
       }
     },
     "bl": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+      "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
       "requires": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",

--- a/src/api/kubectl/secrets.ts
+++ b/src/api/kubectl/secrets.ts
@@ -3,10 +3,10 @@ import {AsyncKubeClient} from './client';
 import {AbstractKubernetesResourceManager, KubeResource, ListOptions, Props} from './kubernetes-resource-manager';
 import {decode as base64decode} from '../../util/base64';
 
-export interface Secret extends KubeResource {
+export interface Secret<T = any> extends KubeResource {
   type: string;
-  stringData?: any;
-  data?: any;
+  stringData?: T;
+  data?: T;
 }
 
 const factory: ObjectFactory = (context: BuildContext) => {
@@ -24,7 +24,7 @@ export class KubeSecret extends AbstractKubernetesResourceManager<Secret> {
   }
 
   async getData<U>(secretName: string, namespace: string): Promise<U> {
-    const secret: Secret = await this.get(secretName, namespace);
+    const secret: Secret<U> = await this.get(secretName, namespace);
 
     if (!secret || !secret.data) {
       return {} as any;
@@ -33,7 +33,7 @@ export class KubeSecret extends AbstractKubernetesResourceManager<Secret> {
     return this.decodeSecretData(secret.data);
   }
 
-  decodeSecretData<U>(secretData: U): any {
+  decodeSecretData<U>(secretData: U): U {
     return Object.keys(secretData).reduce((decodedResults, currentKey) => {
       if (secretData[currentKey]) {
         decodedResults[currentKey] = base64decode(secretData[currentKey]);

--- a/src/services/credentials/credentials.ts
+++ b/src/services/credentials/credentials.ts
@@ -97,7 +97,7 @@ export class CredentialsImpl implements Credentials {
         this.getJenkinsCredentials(namespace),
       ]),
       this.kubeSecret.listData(listOptions, ['jenkins-access']),
-      this.kubeConfigMap.listData(listOptions, ['ibmcloud-config']),
+      this.kubeConfigMap.listData(listOptions, ['ibmcloud-config', 'cloud-config']),
     ]);
 
     return this.group(_.assign({}, ...(_.flatten(results))));

--- a/src/util/server-url.ts
+++ b/src/util/server-url.ts
@@ -1,0 +1,12 @@
+const {KubeConfig} = require('kubernetes-client');
+
+export class ServerUrl {
+  async getServerUrl(): Promise<string> {
+    const kubeConfig = new KubeConfig();
+    kubeConfig.loadFromDefault();
+
+    const cluster = kubeConfig.getCurrentCluster();
+
+    return cluster.server;
+  }
+}


### PR DESCRIPTION
- Removes cloud-config config map dependency to find cluster type
- Looks for the existence of a project named "openshift". If the project doesn't exist or the get project command throws an error then it is kubernetes
- Removes dependency on ibmcloud-config and cloud-config in `register-tekton-pipeline`