### PR TITLE
sync: Reduces required permissions

### DIFF
--- a/src/api/kubectl/index.ts
+++ b/src/api/kubectl/index.ts
@@ -7,6 +7,7 @@ export * from './kubernetes-resource-manager';
 export * from './namespace';
 export * from './pod';
 export * from './project';
+export * from './project-cli';
 export * from './role';
 export * from './role-binding';
 export * from './route';

--- a/src/api/kubectl/namespace.ts
+++ b/src/api/kubectl/namespace.ts
@@ -7,6 +7,7 @@ export interface Namespace extends KubeResource {
 
 export abstract class AbstractKubeNamespace<T extends KubeResource> {
   abstract async create(name: string): Promise<T>;
+  abstract async list(name: string): Promise<T[]>;
   abstract async exists(name: string): Promise<boolean>;
 }
 
@@ -33,6 +34,12 @@ export class KubeNamespace implements AbstractKubeNamespace<Namespace> {
     }} as KubeBody<Namespace>);
 
     return result.body;
+  }
+
+  async list(): Promise<Namespace[]> {
+    const client: KubeClient = await this.client.get();
+
+    return client.api.v1.namespace.get();
   }
 
   async exists(name: string): Promise<boolean> {

--- a/src/api/kubectl/project-cli.ts
+++ b/src/api/kubectl/project-cli.ts
@@ -1,0 +1,39 @@
+import {AbstractKubeNamespace} from './namespace';
+import {Project} from './project';
+import {ChildProcess} from '../../util/child-process';
+
+export class OcpProjectCli implements AbstractKubeNamespace<Project> {
+
+  async create(name: string): Promise<Project> {
+    const childProcess = new ChildProcess();
+
+    await childProcess.exec(`oc new-project ${name}`);
+
+    return this.buildProject(name);
+  }
+
+  buildProject(name: string): Project {
+    return {
+      apiVersion: 'project.openshift.io/v1',
+      kind: 'Project',
+      metadata: {
+        name
+      },
+      status: {}
+    }
+  }
+
+  async list(): Promise<Project[]> {
+    const childProcess = new ChildProcess();
+
+    const {stdout, stderr} = await childProcess.exec('oc projects -q');
+
+    return stdout.toString().split(/\r?\n/).map(this.buildProject);
+  }
+
+  async exists(name: string): Promise<boolean> {
+    const projects: Project[] = await this.list();
+
+    return projects.filter(p => p.metadata.name === name).length > 0;
+  }
+}

--- a/src/api/kubectl/project.ts
+++ b/src/api/kubectl/project.ts
@@ -2,7 +2,7 @@ import {BuildContext, Factory, ObjectFactory} from 'typescript-ioc';
 
 import {AsyncKubeClient, AsyncOcpClient, KubeClient} from './client';
 import {KubeBody, KubeResource} from './kubernetes-resource-manager';
-import {AbstractKubeNamespace} from './namespace';
+import {AbstractKubeNamespace, Namespace} from './namespace';
 
 export interface Project extends KubeResource {
   spec?: {
@@ -34,6 +34,12 @@ export class OcpProject implements AbstractKubeNamespace<Project> {
       }} as KubeBody<Project>);
 
     return result.body;
+  }
+
+  async list(): Promise<Project[]> {
+    const client: KubeClient = await this.client.get();
+
+    return client.apis['project.openshift.io'].v1.project.get();
   }
 
   async exists(name: string): Promise<boolean> {

--- a/src/commands/namespace.ts
+++ b/src/commands/namespace.ts
@@ -44,7 +44,7 @@ exports.handler = async (argv: Arguments<NamespaceOptionsModel & {verbose: boole
     process.exit(1);
   }
 
-  console.log(`Setting up namespace ${chalk.yellow(argv.namespace)} and serviceAccount ${chalk.yellow(argv.serviceAccount)}`);
+  console.log(`Setting up namespace ${chalk.yellow(argv.namespace)}`);
 
   const spinner: Logger = argv.verbose ? new VerboseLogger() : ora('Setting up namespace: ' + argv.namespace).start();
 

--- a/src/commands/pull-secret.ts
+++ b/src/commands/pull-secret.ts
@@ -1,0 +1,66 @@
+import {Arguments, Argv} from 'yargs';
+import {Container} from 'typescript-ioc';
+import * as ora from 'ora';
+import * as chalk from 'chalk';
+
+import {Namespace, NamespaceOptionsModel} from '../services/namespace';
+import {Logger, VerboseLogger} from '../util/logger';
+
+export const command = 'pull-secret [namespace]';
+export const desc = 'Copy pull secrets into the provided project from the template namespace';
+export const builder = (yargs: Argv<any>) => {
+  return yargs
+    .positional('namespace', {
+      require: false,
+      describe: 'The namespace into which the pull-secret(s) will be created',
+    })
+    .option('templateNamespace', {
+      alias: 't',
+      describe: 'the template namespace that will be the source of the config',
+      default: 'tools',
+      type: 'string',
+    })
+    .option('serviceAccount', {
+      alias: 'z',
+      describe: 'the service account that will be used within the namespace',
+      default: 'default',
+      type: 'string',
+    })
+    .option('dev', {
+      describe: 'flag to indicate this is a development namespace and that development artifacts should be created',
+      type: 'boolean',
+    })
+    .option('verbose', {
+      describe: 'flag to produce more verbose logging',
+      type: 'boolean'
+    })
+};
+exports.handler = async (argv: Arguments<NamespaceOptionsModel & {verbose: boolean}>) => {
+  const namespaceBuilder: Namespace = Container.get(Namespace);
+
+  if (!argv.namespace) {
+    argv.namespace = await namespaceBuilder.getCurrentProject();
+  }
+
+  if (!argv.namespace) {
+    console.log(chalk.red(`Please specify the namespace as the first argument. Run '${argv.$0} namespace --help' for more information`));
+    process.exit(1);
+  }
+
+  console.log(`Setting up pull secrets in ${chalk.yellow(argv.namespace)}`);
+
+  const spinner: Logger = argv.verbose ? new VerboseLogger() : ora('Setting up pull secrets: ' + argv.namespace).start();
+
+  function statusCallback(status: string) {
+    spinner.text = status;
+  }
+
+  try {
+    return await namespaceBuilder.pullSecret(argv, statusCallback);
+  } catch (err) {
+    console.log('Error setting up secrets', err);
+    process.exit(1);
+  } finally {
+    spinner.stop();
+  }
+};

--- a/src/script-gitops.ts
+++ b/src/script-gitops.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+import {addCommandToArgs} from './util/add-command-to-args';
+
+process.argv = addCommandToArgs(process.argv, 'gitops');
+
+require('./script');

--- a/src/services/namespace/namespace.api.ts
+++ b/src/services/namespace/namespace.api.ts
@@ -5,6 +5,8 @@ export abstract class Namespace {
 
   async abstract setCurrentProject(namespace: string);
 
+  async abstract pullSecret(namespaceOptions: NamespaceOptionsModel, notifyStatus: (status: string) => void): Promise<string>;
+
   async abstract create(namespaceOptions: NamespaceOptionsModel, notifyStatus?: (status: string) => void): Promise<string>;
 
   async abstract setupJenkins(namespace: string, templateNamespace: string, clusterType: string, notifyStatus: (status: string) => void);

--- a/src/services/namespace/namespace.spec.ts
+++ b/src/services/namespace/namespace.spec.ts
@@ -245,18 +245,6 @@ describe('namespace', () => {
         });
       });
 
-      test('then should setup pull secrets from tools namespace', async () => {
-        await classUnderTest.create(namespaceOptions);
-
-        expect(setupPullSecrets).toHaveBeenCalledWith(namespace, templateNamespace);
-      });
-
-      test('then should setup service account with pull secrets', async () => {
-        await classUnderTest.create(namespaceOptions);
-
-        expect(setupServiceAccountWithPullSecrets).toHaveBeenCalledWith(namespace, serviceAccount);
-      });
-
       describe('and when dev flag is false', () => {
         beforeEach(() => {
           namespaceOptions.dev = false;

--- a/src/services/namespace/namespace.ts
+++ b/src/services/namespace/namespace.ts
@@ -80,6 +80,17 @@ export class NamespaceImpl implements Namespace {
     return defaultValue;
   }
 
+  async pullSecret({namespace, templateNamespace, serviceAccount}: NamespaceOptionsModel, notifyStatus: (status: string) => void = noopNotifyStatus): Promise<string> {
+
+    notifyStatus('Setting up pull secrets');
+    await this.setupPullSecrets(namespace, templateNamespace);
+
+    notifyStatus(`Adding pull secrets to serviceAccount: ${serviceAccount}`);
+    await this.setupServiceAccountWithPullSecrets(namespace, serviceAccount);
+
+    return namespace;
+  }
+
   async create({namespace, templateNamespace, serviceAccount, dev}: NamespaceOptionsModel, notifyStatus: (status: string) => void = noopNotifyStatus): Promise<string> {
 
     const {clusterType, serverUrl} = await this.clusterType.getClusterType(templateNamespace);

--- a/src/services/register-pipeline/register-tekton-pipeline.spec.ts
+++ b/src/services/register-pipeline/register-tekton-pipeline.spec.ts
@@ -47,6 +47,7 @@ describe('register-tekton-pipeline', () => {
       getCurrentProject: jest.fn(),
       setCurrentProject: jest.fn(),
       setupJenkins: jest.fn(),
+      pullSecret: jest.fn(),
     };
     Container.bind(Namespace)
       .factory(factoryFromValue(namespaceBuilder));

--- a/src/util/cluster-type.spec.ts
+++ b/src/util/cluster-type.spec.ts
@@ -12,13 +12,13 @@ describe('cluster-type', () => {
 
   let classUnderTest: ClusterType;
 
-  let projectExists: Mock;
+  let projectList: Mock;
   let getServerUrl: Mock;
 
   beforeEach(() => {
-    projectExists = jest.fn();
+    projectList = jest.fn();
     const project = {
-      exists: projectExists
+      list: projectList
     };
     Container.bind(OcpProject).factory(() => project);
 
@@ -38,9 +38,9 @@ describe('cluster-type', () => {
       getServerUrl.mockResolvedValue(serverUrl);
     });
 
-    describe('when openshift project exists', () => {
+    describe('when openshift list returns a value', () => {
       beforeEach(() => {
-        projectExists.mockResolvedValue(true);
+        projectList.mockResolvedValue([]);
       });
 
       test('then clusterType should be openshift', async () => {
@@ -48,13 +48,13 @@ describe('cluster-type', () => {
         expect(await classUnderTest.getClusterType('namespace'))
           .toEqual({clusterType, serverUrl});
 
-        expect(projectExists).toHaveBeenCalledWith('openshift');
+        expect(projectList).toHaveBeenCalled();
       });
     });
 
-    describe('when openshift project does not exist', () => {
+    describe('when project list throws an error', () => {
       beforeEach(() => {
-        projectExists.mockResolvedValue(false);
+        projectList.mockRejectedValue(new Error('no resource named project'));
       });
 
       test('then clusterType should be kubernetes', async () => {
@@ -62,21 +62,7 @@ describe('cluster-type', () => {
         expect(await classUnderTest.getClusterType('namespace'))
           .toEqual({clusterType, serverUrl});
 
-        expect(projectExists).toHaveBeenCalledWith('openshift');
-      });
-    });
-
-    describe('when project.exists throws an error', () => {
-      beforeEach(() => {
-        projectExists.mockRejectedValue(new Error('no resource named project'));
-      });
-
-      test('then clusterType should be kubernetes', async () => {
-        const clusterType = 'kubernetes';
-        expect(await classUnderTest.getClusterType('namespace'))
-          .toEqual({clusterType, serverUrl});
-
-        expect(projectExists).toHaveBeenCalledWith('openshift');
+        expect(projectList).toHaveBeenCalled();
       });
     });
   });

--- a/src/util/cluster-type.ts
+++ b/src/util/cluster-type.ts
@@ -38,13 +38,13 @@ export class ClusterType {
     };
   }
 
-  async getClusterTypeInternal(): Promise<"openshift" | "kubernetes"> {
+  async getClusterTypeInternal(): Promise<'openshift' | 'kubernetes'> {
     try {
-      const isOpenShift = await this.project.exists("openshift");
+      await this.project.list();
 
-      return isOpenShift ? "openshift" : "kubernetes";
+      return 'openshift';
     } catch (err) {
-      return "kubernetes";
+      return 'kubernetes';
     }
   }
 }


### PR DESCRIPTION
- Changes the mechanism to detect cluster type to not require cluster admin to work properly
- Uses `oc new-project` instead of the project api to create the project to reduce permission requirement
- Removes logic to copy the pull secret and add to the default service account