### PR TITLE
Register the gitops command as a kubectl/oc plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "kubectl-enable": "dist/script-enable.js",
     "kubectl-endpoints": "dist/script-endpoints.js",
     "kubectl-git": "dist/script-git.js",
+    "kubectl-gitops": "dist/script-gitops.js",
     "kubectl-git-secret": "dist/script-git-secret.js",
     "kubectl-pipeline": "dist/script-pipeline.js",
     "kubectl-sync": "dist/script-namespace.js",


### PR DESCRIPTION
The gitops script was added but it wasn't exposed as a binary