### PR TITLE
pipeline: Fixes issue detecting pipeline type from local directory

### DIFF
--- a/src/api/git/local.ts
+++ b/src/api/git/local.ts
@@ -1,23 +1,26 @@
-import {LocalGitApi} from './git.api';
-import fs from 'fs';
+import {promises as fsPromises} from 'fs';
 import path from 'path';
+
+import {LocalGitApi} from './git.api';
 import {ChildProcess} from '../../util/child-process';
 
 export class LocalGitRepo implements LocalGitApi {
   constructor(private repoPath: string = process.cwd()) {}
 
   async listFiles(): Promise<Array<{path: string, url?: string}>> {
-    const files: string[] = await fs.promises.readdir(this.repoPath);
+    const files: string[] = await fsPromises.readdir(this.repoPath);
 
-    return files.map(filename => ({
+    const filenames = files.map(filename => ({
       path: filename
     }));
+
+    return filenames;
   }
 
   async getFileContents(fileDescriptor: {path: string, url?: string}): Promise<string | Buffer> {
     return new Promise<Buffer>((resolve, reject) => {
       console.log('Executing file read: ' + fileDescriptor.path);
-      resolve(fs.promises.readFile(path.join(this.repoPath, fileDescriptor.path)));
+      resolve(fsPromises.readFile(path.join(this.repoPath, fileDescriptor.path)));
     });
   }
 


### PR DESCRIPTION
There was an error importing the `fs` module to the local git repo implementation. It was failing silently when trying to detect the runtime