### PR TITLE
pipeline: Reduces permissions needed to get console url

### DIFF
--- a/src/services/console/console.service.ts
+++ b/src/services/console/console.service.ts
@@ -18,7 +18,9 @@ export class GetConsoleUrlService implements GetConsoleUrlApi {
     const {clusterType} = await this.clusterType.getClusterType();
 
     if (clusterType == 'openshift') {
-      return this.route.getUrls('openshift-console', 'console').then(urls => urls[0]);
+      return this.childProcess
+        .exec('oc whoami --show-console')
+        .then(({stdout}: {stdout: string, stderr: string}) => stdout.trim());
     } else {
       const {clusterName, region} = await this.kubeConfigMap.getData<{CLUSTER_NAME, REGION}>('ibmcloud-config', namespace)
         .then(val => ({


### PR DESCRIPTION
- Changes the logic to retrieve the console url from the cluster to reduce the access needed

ibm-garage-cloud/planning#680