### PR TITLE
pipeline: Adds support for Tekton Triggers v0.8.0 for webhook creation

### DIFF
--- a/src/services/register-pipeline/register-tekton-pipeline.ts
+++ b/src/services/register-pipeline/register-tekton-pipeline.ts
@@ -616,8 +616,8 @@ export class RegisterTektonPipeline implements RegisterPipeline {
             ],
             resourcetemplates: [
               pipelineRunBuilder({
-                gitRevision: '$(params.gitrevision)',
-                gitUrl: '$(params.gitrepositoryurl)',
+                gitRevision: '$(tt.params.gitrevision)',
+                gitUrl: '$(tt.params.gitrepositoryurl)',
                 template: true
               })
             ]


### PR DESCRIPTION
- Adds 'tt.' prefix to params in Tekton trigger template

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>