### PR TITLE
gitops: Allows git url to be passed as parameter

### DIFF
--- a/src/commands/gitops.ts
+++ b/src/commands/gitops.ts
@@ -3,10 +3,15 @@ import {Arguments, Argv} from 'yargs';
 import {handler as gitSecretHandler} from './git-secret';
 import {CreateGitSecretOptions} from '../services/git-secret';
 
-export const command = 'gitops';
+export const command = 'gitops [gitUrl]';
 export const desc = 'Registers the git repository in the kubernetes cluster as the gitops repository for the given namespace';
 export const builder = (yargs: Argv<any>) => {
   return yargs
+    .positional('gitUrl', {
+      description: 'Provides the git url for the repository that should be registered for GitOps',
+      type: 'string',
+      demandOption: false,
+    })
     .option('namespace', {
       alias: 'n',
       type: 'string',

--- a/src/services/git-secret/create-git-secret.api.ts
+++ b/src/services/git-secret/create-git-secret.api.ts
@@ -77,6 +77,7 @@ export interface GitAuthResponse {
 }
 
 export class CreateGitSecretOptions extends GitParametersOptions {
+  gitUrl?: string;
   namespaces: string[] | string;
   values?: string;
   replace?: boolean;


### PR DESCRIPTION
- Registering the gitops repository in a cluster namespace can be done without cloning the repository

Signed-off-by: Sean Sundberg <seansund@us.ibm.com>